### PR TITLE
Feature/publish mvn central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Testerra Selenoid Connector
 
 <p align="center">
+    <a href="https://mvnrepository.com/artifact/io.testerra/selenoid-connector" title="MavenCentral"><img src="https://img.shields.io/maven-central/v/io.testerra/selenoid-connector?label=Maven%20Central"></a>
     <a href="/../../commits/" title="Last Commit"><img src="https://img.shields.io/github/last-commit/telekom/testerra-selenoid-connector?style=flat"></a>
     <a href="/../../issues" title="Open Issues"><img src="https://img.shields.io/github/issues/telekom/testerra-selenoid-connector?style=flat"></a>
     <a href="./LICENSE" title="License"><img src="https://img.shields.io/badge/License-Apache%202.0-green.svg?style=flat"></a>
@@ -20,7 +21,7 @@
 This module provides additional features for [Testerra Framework](https://github.com/telekom/testerra) for automated tests.
 
 Using a Selenium Grid based on [Selenoid](https://github.com/aerokube/selenoid) this module provides access to videos and VNC
-streams.
+streams. When activated, video files are automatically added to the Testerra report. 
 
 The module will register automatically by using `ModuleHook`.
 
@@ -28,7 +29,7 @@ The module will register automatically by using `ModuleHook`.
 
 ### Requirements
 
-* Testerra in Version: `1.0-RC-29`
+![Maven Central](https://img.shields.io/maven-central/v/io.testerra/core/1.0-RC-32?label=Testerra)
 
 ### Usage
 
@@ -37,7 +38,7 @@ Include the following dependency in your project.
 Gradle:
 
 ````groovy
-implementation 'eu.tsystems.mms.tic.testerra:selenoid-connector:1.0-RC-12'
+implementation 'io.testerra:selenoid-connector:1.0'
 ````
 
 Maven:
@@ -45,9 +46,9 @@ Maven:
 ````xml
 
 <dependency>
-    <groupId>eu.tsystems.mms.tic.testerra</groupId>
+    <groupId>io.testerra</groupId>
     <artifactId>selenoid-connector</artifactId>
-    <version>1.0-RC-12</version>
+    <version>1.0</version>
 </dependency>
 ````
 
@@ -152,29 +153,24 @@ you to all of them.
 
 ## Publication
 
-### ... to a Maven repo
+This module is deployed and published to Maven Central. All JAR files are signed via Gradle signing plugin.
 
-_Publishing to local repo_
-```shell
-gradle publishToMavenLocal
-```
+The following properties have to be set via command line or ``~/.gradle/gradle.properties``
 
-_Publishing to remote repo_
-```shell
-gradle publish -DdeployUrl=<repo-url> -DdeployUsername=<repo-user> -DdeployPassword=<repo-password>
-```
+| Property                      | Description                                         |
+| ----------------------------- | --------------------------------------------------- |
+| `moduleVersion`               | Version of deployed module, default is `1-SNAPSHOT` |
+| `deployUrl`                   | Maven repository URL                                |
+| `deployUsername`              | Maven repository username                           |
+| `deployPassword`              | Maven repository password                           |
+| `signing.keyId`               | GPG private key ID (short form)                     |
+| `signing.password`            | GPG private key password                            |
+| `signing.secretKeyRingFile`   | Path to GPG private key                             |
 
-_Set a custom version_
-```shell
-gradle publish -DmoduleVersion=<version>
-```
-
-### ... to GitHub Packages
-
-Some hints for using GitHub Packages as Maven repository
-
-* Deploy URL is https://maven.pkg.github.com/OWNER/REPOSITRY
-* As password generate an access token and grant permissions to ``write:packages`` (Settings -> Developer settings -> Personal access token)
+If all properties are set, call the following to build, deploy and release this module:
+````shell
+gradle publish closeAndReleaseRepository
+````
 
 ## Code of Conduct
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'io:driver-ui-desktop:' + testerraCompileVersion
+    compileOnly 'io.testerra:driver-ui-desktop:' + testerraCompileVersion
     implementation 'org.apache.httpcomponents:httpclient:4.5.12'
     implementation 'com.google.code.gson:gson:2.8.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,16 @@
+plugins {
+    id "io.codearte.nexus-staging" version "0.30.0"
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
+apply plugin: 'io.codearte.nexus-staging'
 
 ext {
     // Minimum required Testerra version
-    testerraCompileVersion = '1.0-RC-29'
+    testerraCompileVersion = '1.0-RC-32'
     // Unit tests use the latest Testerra version
     testerraTestVersion = '[1.0-RC,2-SNAPSHOT)'
     moduleVersion = '1-SNAPSHOT'
@@ -12,7 +18,7 @@ ext {
         moduleVersion = System.getProperty('moduleVersion')
     }
 
-    group 'eu.tsystems.mms.tic.testerra'
+    group 'io.testerra'
     version moduleVersion
 }
 
@@ -24,12 +30,12 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'eu.tsystems.mms.tic.testerra:driver-ui-desktop:' + testerraCompileVersion
+    compileOnly 'io:driver-ui-desktop:' + testerraCompileVersion
     implementation 'org.apache.httpcomponents:httpclient:4.5.12'
     implementation 'com.google.code.gson:gson:2.8.6'
 
-    testImplementation 'eu.tsystems.mms.tic.testerra:driver-ui-desktop:' + testerraTestVersion
-    testImplementation 'eu.tsystems.mms.tic.testerra:report-ng:' + testerraTestVersion
+    testImplementation 'io.testerra:driver-ui-desktop:' + testerraTestVersion
+    testImplementation 'io.testerra:report-ng:' + testerraTestVersion
 }
 
 test {

--- a/publish.gradle
+++ b/publish.gradle
@@ -8,7 +8,7 @@ ext {
     packagingType = 'jar'
 
     siteUrl = 'https://testerra.io'
-    gitUrl = 'https://github.com/telekom/testerra-selenoid-connector.git'
+    gitUrl = 'scm:git:git://github.com/telekom/testerra-selenoid-connector.git'
     gitHttpsUrl = 'https://github.com/telekom/testerra-selenoid-connector/'
 
     developerId = 'MMS'

--- a/publish.gradle
+++ b/publish.gradle
@@ -2,94 +2,112 @@
  * Maven publishing configuration
  * */
 
-// Maven basis attributes
+// Maven pom.xml attributes
 ext {
-  libraryName = 'Testerra'
-  artifact = project.getName().toLowerCase()
-  packagingType = 'jar'
+    libraryName = 'Testerra Selenoid Connector'
+    packagingType = 'jar'
 
-  libraryDescription = "Testerra ${project.getName()} module"
+    siteUrl = 'https://testerra.io'
+    gitUrl = 'https://github.com/telekom/testerra-selenoid-connector.git'
+    gitHttpsUrl = 'https://github.com/telekom/testerra-selenoid-connector/'
 
-  siteUrl = 'https://testerra.io'
-  gitUrl = 'https://github.com/telekom/testerra-selenoid-connector.git'
-  issueUrl = 'https://github.com/telekom/testerra-selenoid-connector/issues'
+    developerId = 'MMS'
+    developerName = 'Testerra Team T-Systems MMS'
+    developerEmail = 'testerra@t-systems-mms.com'
+    developerOrganization = 'T-Systems MMS'
+    developerOrganizationUrl = 'https://www.t-systems-mms.com/'
 
-  developerId = 'MMS'
-  developerName = 'Testerra Team T-Systems MMS'
-  developerEmail = 'testerra@t-systems-mms.com'
-
-  licenseName = 'The Apache Software License, Version 2.0'
-  licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-  allLicenses = ["Apache-2.0"]
+    licenseName = 'The Apache Software License, Version 2.0'
+    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    allLicenses = ["Apache-2.0"]
 }
 
-// Set up the Maven publication.
-install {
-  repositories.mavenInstaller {
-    // This generates POM.xml with proper parameters
-    pom.project {
-      packaging packagingType
-      groupId group
-      artifactId artifact
-
-      // Add your description here
-      name libraryName
-      description libraryDescription
-      url siteUrl
-
-      // Set your license
-      licenses {
-        license {
-          name licenseName
-          url licenseUrl
-        }
-      }
-      developers {
-        developer {
-          id developerId
-          name developerName
-          email developerEmail
-        }
-      }
-      scm {
-        connection gitUrl
-        developerConnection gitUrl
-        url siteUrl
-      }
-
-    }
-  }
+nexusStaging {
+    serverUrl = "https://s01.oss.sonatype.org/service/local/"
+    packageGroup = "io.testerra"
+    username = System.getProperty("deployUsername")
+    password = System.getProperty("deployPassword")
 }
 
 // Publish to a Maven repository
 allprojects {
 
-  publishing {
+    def libraryDescription = "Testerra test automation framework - ${project.getName()} module"
+
+    javadoc {
+        // Support JDK 8 annotations
+        options.tags = [
+                "implNote:a:Implementation Note:",
+                "apiNote:a:API Note:",
+                "implSpec:a:Implementation Requirements:"
+        ]
+        // Prevent errors during generation
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
 
     task sourcesJar(type: Jar, dependsOn: classes) {
-      archiveClassifier.set('sources')
-      from sourceSets.main.allSource
+        archiveClassifier.set('sources')
+        from sourceSets.main.allSource
     }
 
-    artifacts {
-      archives sourcesJar
+    task javadocJar(type: Jar) {
+        archiveClassifier.set('javadoc')
+        from javadoc
     }
 
-    publications {
-      mavenJava(MavenPublication) {
-        from components.java
-        artifact sourcesJar
-      }
-    }
+    publishing {
 
-    repositories {
-      maven {
-        url System.getProperty("deployUrl", "none")
-        credentials {
-          username System.getProperty("deployUsername", "none")
-          password System.getProperty("deployPassword", "none")
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+                artifact sourcesJar
+                artifact javadocJar
+
+                // Custom pom
+                pom {
+
+                    name = libraryName
+                    description = libraryDescription
+                    url = siteUrl
+
+                    licenses {
+                        license {
+                            name = licenseName
+                            url = licenseUrl
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = developerId
+                            name = developerName
+                            email = developerEmail
+                            organization = developerOrganization
+                            organizationUrl = developerOrganizationUrl
+                        }
+                    }
+
+                    scm {
+                        connection = gitUrl
+                        developerConnection = gitUrl
+                        url = gitHttpsUrl
+                    }
+                }
+            }
         }
-      }
+
+        repositories {
+            maven {
+                url System.getProperty("deployUrl", "none")
+                credentials {
+                    username System.getProperty("deployUsername", "none")
+                    password System.getProperty("deployPassword", "none")
+                }
+            }
+        }
+
+        signing {
+            sign publishing.publications.mavenJava
+        }
     }
-  }
 }


### PR DESCRIPTION
# Important note
From this date all future deployments are published under the groupId io.testerra.

# Description

- Changed groupid to io.testerra based of MavenCentral requirements
- Changed and fixed publishing tasks
- Added support for MavenCentral (Sonatype Nexus) to close and release the packages
- Added signing of all JAR files
- Added Javadoc generating
- Updated documentation