### PR TITLE
Moved initialization of NodeInfo to SelenoidHelper

### DIFF
--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
@@ -61,7 +61,7 @@ public class SelenoidHelper implements Loggable {
 
     }
 
-    public NodeInfo getNodeInfo(URL seleniumUrl, String sessionId) {
+    public void updateNodeInfo(URL seleniumUrl, String remoteSessionId, SessionContext sessionContext) {
         String url = seleniumUrl.toString();
 
         url = url.replace("/wd/hub", "");
@@ -70,14 +70,13 @@ public class SelenoidHelper implements Loggable {
          * See https://aerokube.com/ggr/latest/#_getting_host_by_session_id for getting Selenoid node information via Selenoid GGR
          */
         try {
-            String nodeResponse = RESTUtils.requestGET(url + "/host/" + sessionId, 30 * 1000, String.class);
+            String nodeResponse = RESTUtils.requestGET(url + "/host/" + remoteSessionId, 30 * 1000, String.class);
             Gson gson = new GsonBuilder().create();
             Map map = gson.fromJson(nodeResponse, Map.class);
             double port = Double.parseDouble(map.get("Port").toString());
-            return new NodeInfo(map.get("Name").toString(), (int) port);
+            sessionContext.setNodeInfo(new NodeInfo(map.get("Name").toString(), (int) port));
         } catch (Exception e) {
             log().warn("Could not get node info: " + e.getMessage());
-            return new NodeInfo(seleniumUrl.getHost(), seleniumUrl.getPort());
         }
     }
 

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
@@ -19,6 +19,7 @@
 package eu.tsystems.mms.tic.testerra.plugins.selenoid.utils;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import eu.tsystems.mms.tic.testerra.plugins.selenoid.request.VideoRequest;
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
@@ -26,9 +27,11 @@ import eu.tsystems.mms.tic.testframework.model.NodeInfo;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.transfer.ThrowablePackedResponse;
 import eu.tsystems.mms.tic.testframework.utils.FileDownloader;
+import eu.tsystems.mms.tic.testframework.utils.RESTUtils;
 import eu.tsystems.mms.tic.testframework.utils.Timer;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
@@ -56,6 +59,26 @@ public class SelenoidHelper implements Loggable {
 
     private SelenoidHelper() {
 
+    }
+
+    public NodeInfo getNodeInfo(URL seleniumUrl, String sessionId) {
+        String url = seleniumUrl.toString();
+
+        url = url.replace("/wd/hub", "");
+
+        /*
+        grid3 mode
+         */
+        try {
+            String nodeResponse = RESTUtils.requestGET(url + "/host/" + sessionId, 30 * 1000, String.class);
+            Gson gson = new GsonBuilder().create();
+            Map map = gson.fromJson(nodeResponse, Map.class);
+            double port = Double.parseDouble(map.get("Port").toString());
+            return new NodeInfo(map.get("Name").toString(), (int) port);
+        } catch (Exception e) {
+            log().warn("Could not get node info: " + e.getMessage());
+            return new NodeInfo(seleniumUrl.getHost(), seleniumUrl.getPort());
+        }
     }
 
     public static SelenoidHelper get() {

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
@@ -66,8 +66,8 @@ public class SelenoidHelper implements Loggable {
 
         url = url.replace("/wd/hub", "");
 
-        /*
-        grid3 mode
+        /**
+         * See https://aerokube.com/ggr/latest/#_getting_host_by_session_id for getting Selenoid node information via Selenoid GGR
          */
         try {
             String nodeResponse = RESTUtils.requestGET(url + "/host/" + sessionId, 30 * 1000, String.class);

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/VideoDesktopWebDriverFactory.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/VideoDesktopWebDriverFactory.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 /**
  * Extends DesktopWebDriverFactory by using selenoid video capabilities.
@@ -68,6 +69,10 @@ public class VideoDesktopWebDriverFactory extends DesktopWebDriverFactory {
 
         // start webdriver with selenoid caps.
         final WebDriver rawWebDriver = super.getRawWebDriver(request, desiredCapabilities, sessionContext);
+
+        if (rawWebDriver instanceof RemoteWebDriver && request.getSeleniumServerUrl() != null) {
+            sessionContext.setNodeInfo(SelenoidHelper.get().getNodeInfo(request.getSeleniumServerUrl(), ((RemoteWebDriver) rawWebDriver).getSessionId().toString()));
+        }
 
         // create a VideoRequest with request and videoName
         final VideoRequest videoRequest = new VideoRequest(sessionContext, videoCaps.asMap().get(SelenoidCapabilityProvider.Caps.videoName.toString()).toString());

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/VideoDesktopWebDriverFactory.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/VideoDesktopWebDriverFactory.java
@@ -71,7 +71,7 @@ public class VideoDesktopWebDriverFactory extends DesktopWebDriverFactory {
         final WebDriver rawWebDriver = super.getRawWebDriver(request, desiredCapabilities, sessionContext);
 
         if (rawWebDriver instanceof RemoteWebDriver && request.getSeleniumServerUrl() != null) {
-            sessionContext.setNodeInfo(SelenoidHelper.get().getNodeInfo(request.getSeleniumServerUrl(), ((RemoteWebDriver) rawWebDriver).getSessionId().toString()));
+            SelenoidHelper.get().updateNodeInfo(request.getSeleniumServerUrl(), ((RemoteWebDriver) rawWebDriver).getSessionId().toString(), sessionContext);
         }
 
         // create a VideoRequest with request and videoName


### PR DESCRIPTION
# Description

* Selenoid node detection is now done in `WebDriverFactory`
* Log level `warn` instead `error` when node could not get detected.
* Requires https://github.com/telekom/testerra/pull/23