### PR TITLE
Bugfix/no videos for reusable sessions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     // Minimum required Testerra version
     testerraCompileVersion = '1.0.0'
     // Unit tests use the latest Testerra version
-    testerraTestVersion = '[1.0-RC,2-SNAPSHOT)'
+    testerraTestVersion = '[1.0,2-SNAPSHOT)'
     moduleVersion = '1-SNAPSHOT'
     if (System.properties.containsKey('moduleVersion')) {
         moduleVersion = System.getProperty('moduleVersion')

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/collector/SelenoidEvidenceVideoCollector.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/collector/SelenoidEvidenceVideoCollector.java
@@ -107,17 +107,14 @@ public class SelenoidEvidenceVideoCollector implements
     }
 
     protected void collectVideoForSessionContext(SessionContext sessionContext) {
-        // Check is session context is a selenoid session
-        if (selenoidHelper.isSelenoidUsed(sessionContext)) {
-            // Check if there exists a video request for this session
-            videoRequestStorage.list().stream()
-                    .filter(videoRequest -> videoRequest.sessionContext == sessionContext)
-                    .findFirst()
-                    .ifPresent(videoRequest -> {
-                        this.downloadLinkAndCleanVideo(videoRequest);
-                        videoRequestStorage.remove(videoRequest);
-                    });
-        }
+        // Check if there exists a video request for this session
+        videoRequestStorage.list().stream()
+                .filter(videoRequest -> videoRequest.sessionContext == sessionContext)
+                .findFirst()
+                .ifPresent(videoRequest -> {
+                    this.downloadLinkAndCleanVideo(videoRequest);
+                    videoRequestStorage.remove(videoRequest);
+                });
     }
 }
 

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/collector/SelenoidEvidenceVideoCollector.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/collector/SelenoidEvidenceVideoCollector.java
@@ -22,21 +22,21 @@ import eu.tsystems.mms.tic.testerra.plugins.selenoid.request.VideoRequest;
 import eu.tsystems.mms.tic.testerra.plugins.selenoid.request.VideoRequestStorage;
 import eu.tsystems.mms.tic.testerra.plugins.selenoid.utils.SelenoidHelper;
 import eu.tsystems.mms.tic.testerra.plugins.selenoid.utils.VideoLoader;
-import eu.tsystems.mms.tic.testframework.interop.VideoCollector;
+import eu.tsystems.mms.tic.testframework.common.PropertyManager;
+import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import eu.tsystems.mms.tic.testframework.report.TestStatusController;
+import eu.tsystems.mms.tic.testframework.report.model.context.MethodContext;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.model.context.Video;
-import eu.tsystems.mms.tic.testframework.utils.WebDriverUtils;
+import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
 import java.util.Optional;
 import java.util.function.Consumer;
 import org.openqa.selenium.WebDriver;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
- * Will collect Videos when Testerra asks for it via {@link VideoCollector#collectVideos()}
+ * Will collect Videos when Testerra closes a WebDriver session
  * Date: 15.04.2020
  * Time: 11:16
  *
@@ -44,33 +44,13 @@ import java.util.List;
  */
 public class SelenoidEvidenceVideoCollector implements
         Consumer<WebDriver>,
-        VideoCollector,
         Loggable
 {
 
     private final SelenoidHelper selenoidHelper = SelenoidHelper.get();
     private final VideoRequestStorage videoRequestStorage = VideoRequestStorage.get();
-    private final ThreadLocal<List<VideoRequest>> videoRequestsForClosedSessions = new ThreadLocal<>();
-
-    /**
-     * This method will be called once per failed testcase
-     * And after all related {@link WebDriver} sessions where closed
-     */
-    @Override
-    public List<Video> getVideos() {
-
-        final List<Video> videoList = new ArrayList<>();
-
-        // Iterate over all closed WebDriver sessions during last teardown and get their videos.
-        if (videoRequestsForClosedSessions.get() != null) {
-            for (final VideoRequest videoRequest : videoRequestsForClosedSessions.get()) {
-                Optional<Video> optionalVideo = downloadLinkAndCleanVideo(videoRequest);
-                optionalVideo.ifPresent(videoList::add);
-            }
-        }
-        videoRequestsForClosedSessions.remove();
-        return videoList;
-    }
+    private final boolean SCREENCASTER_ACTIVE_ON_SUCCESS = PropertyManager.getBooleanProperty(TesterraProperties.SCREENCASTER_ACTIVE_ON_SUCCESS, false);
+    private final boolean SCREENCASTER_ACTIVE_ON_FAILED = PropertyManager.getBooleanProperty(TesterraProperties.SCREENCASTER_ACTIVE_ON_FAILED, true);
 
     /**
      * This method will be called for each WebDriver that is still active after a Test method
@@ -80,25 +60,34 @@ public class SelenoidEvidenceVideoCollector implements
      */
     @Override
     public void accept(WebDriver webDriver) {
-        if (WebDriverSessionsManager.isExclusiveSession(webDriver)) {
-            for (final VideoRequest videoRequest : videoRequestStorage.global()) {
-                downloadLinkAndCleanVideo(videoRequest);
-            }
-        } else {
-            if (videoRequestsForClosedSessions.get() == null) {
-                videoRequestsForClosedSessions.set(new LinkedList<>());
-            }
-            WebDriverSessionsManager.getSessionContext(webDriver).ifPresent(sessionContext -> {
-                if (selenoidHelper.isSelenoidUsed(sessionContext)) {
-                    videoRequestStorage.list().stream()
-                            .filter(videoRequest -> videoRequest.sessionContext == sessionContext)
-                            .findFirst()
-                            .ifPresent(videoRequest -> videoRequestsForClosedSessions.get().add(videoRequest));
+
+        MethodContext currentMethodContext = ExecutionContextController.getCurrentMethodContext();
+        if (currentMethodContext != null) {
+            currentMethodContext.getTestNgResult().ifPresent(testResult -> {
+                /**
+                 * Don't handle session when there is no video
+                 */
+                if (testResult.getMethod().isTest()) {
+                    if (currentMethodContext.isFailed() && SCREENCASTER_ACTIVE_ON_FAILED) {
+                        collectVideoForWebDriver(webDriver);
+                    } else if (currentMethodContext.isPassed() && SCREENCASTER_ACTIVE_ON_SUCCESS) {
+                        collectVideoForWebDriver(webDriver);
+
+                    } else if (currentMethodContext.isSkipped()) {
+                        if (currentMethodContext.getStatus() == TestStatusController.Status.FAILED_RETRIED) {
+                            collectVideoForWebDriver(webDriver);
+                        }
+                    }
                 }
             });
+        } else if (WebDriverSessionsManager.isExclusiveSession(webDriver)) {
+            collectVideoForWebDriver(webDriver);
         }
     }
 
+    /**
+     * Downloads the video and add its to the {@link SessionContext}
+     */
     private Optional<Video> downloadLinkAndCleanVideo(final VideoRequest videoRequest) {
         Video video = new VideoLoader().download(videoRequest);
 
@@ -108,9 +97,25 @@ public class SelenoidEvidenceVideoCollector implements
         } else {
             log().warn("Unable to download video");
         }
-        videoRequestStorage.remove(videoRequest);
 
         return Optional.ofNullable(video);
+    }
+
+    protected void collectVideoForWebDriver(WebDriver webDriver) {
+        // Check if session exists in general
+        WebDriverSessionsManager.getSessionContext(webDriver).ifPresent(closedSessionContext -> {
+            // Check is session context is a selenoid session
+            if (selenoidHelper.isSelenoidUsed(closedSessionContext)) {
+                // Check if there exists a video request for this session
+                videoRequestStorage.list().stream()
+                        .filter(videoRequest -> videoRequest.sessionContext == closedSessionContext)
+                        .findFirst()
+                        .ifPresent(videoRequest -> {
+                            this.downloadLinkAndCleanVideo(videoRequest);
+                            videoRequestStorage.remove(videoRequest);
+                        });
+            }
+        });
     }
 }
 

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/hooks/SelenoidVideoHook.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/hooks/SelenoidVideoHook.java
@@ -18,16 +18,13 @@
  */
 package eu.tsystems.mms.tic.testerra.plugins.selenoid.hooks;
 
-import com.google.common.eventbus.EventBus;
 import eu.tsystems.mms.tic.testerra.plugins.selenoid.collector.SelenoidEvidenceVideoCollector;
 import eu.tsystems.mms.tic.testerra.plugins.selenoid.utils.SelenoidProperties;
 import eu.tsystems.mms.tic.testerra.plugins.selenoid.webdriver.VideoDesktopWebDriverFactory;
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.constants.Browsers;
 import eu.tsystems.mms.tic.testframework.hooks.ModuleHook;
-import eu.tsystems.mms.tic.testframework.interop.TestEvidenceCollector;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
-import eu.tsystems.mms.tic.testframework.report.TesterraListener;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
 
@@ -70,15 +67,6 @@ public class SelenoidVideoHook implements ModuleHook, Loggable {
 
             // Register a shutdown handler to get informed about closing WebDriver sessions
             WebDriverSessionsManager.registerWebDriverAfterShutdownHandler(selenoidEvidenceVideoCollector);
-
-            // Register a evidence collector to link videos as test evidence when testerra will call it.
-            TestEvidenceCollector.registerVideoCollector(selenoidEvidenceVideoCollector);
-
-            // Register a AfterMethodWorker that will run AFTER video fetching - will ensure that video requests are discarded.
-//            EventBus eventBus = TesterraListener.getEventBus();
-//
-//            // Register a Report Worker to fetch all videos from exclusive sessions and all videos that are not fetched but should be fetched.
-//            eventBus.register(selenoidEvidenceVideoCollector);
         }
     }
 

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/request/VideoRequestStorage.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/request/VideoRequestStorage.java
@@ -21,9 +21,8 @@ package eu.tsystems.mms.tic.testerra.plugins.selenoid.request;
 
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Stores {@link VideoRequest} and associated {@link eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverRequest}
@@ -37,8 +36,7 @@ public class VideoRequestStorage implements Loggable {
 
     private final static VideoRequestStorage INSTANCE = new VideoRequestStorage();
 
-    private static final ThreadLocal<List<VideoRequest>> VIDEO_WEBDRIVER_REQUESTS = new ThreadLocal<>();
-    private static final List<VideoRequest> GLOBAL_VIDEO_WEBDRIVER_REQUESTS = Collections.synchronizedList(new LinkedList<>());
+    private static final Queue<VideoRequest> GLOBAL_VIDEO_WEBDRIVER_REQUESTS = new ConcurrentLinkedQueue<>();
 
     private VideoRequestStorage() {
 
@@ -53,16 +51,7 @@ public class VideoRequestStorage implements Loggable {
      *
      * @return List
      */
-    public List<VideoRequest> list() {
-        return VIDEO_WEBDRIVER_REQUESTS.get();
-    }
-
-    /**
-     * Returns global list of current valid {@link VideoRequest}
-     *
-     * @return List
-     */
-    public List<VideoRequest> global() {
+    public Queue<VideoRequest> list() {
         return GLOBAL_VIDEO_WEBDRIVER_REQUESTS;
     }
 
@@ -73,13 +62,7 @@ public class VideoRequestStorage implements Loggable {
      */
     public void store(VideoRequest request) {
 
-        // creating storage when not created yet.
-        if (VIDEO_WEBDRIVER_REQUESTS.get() == null) {
-            VIDEO_WEBDRIVER_REQUESTS.set(new LinkedList<>());
-        }
-
         // adding
-        VIDEO_WEBDRIVER_REQUESTS.get().add(request);
         GLOBAL_VIDEO_WEBDRIVER_REQUESTS.add(request);
     }
 
@@ -89,39 +72,6 @@ public class VideoRequestStorage implements Loggable {
      * @param request {@link VideoRequest}
      */
     public void remove(VideoRequest request) {
-
-        if (VIDEO_WEBDRIVER_REQUESTS.get() != null) {
-            VIDEO_WEBDRIVER_REQUESTS.get().remove(request);
-        }
-
         GLOBAL_VIDEO_WEBDRIVER_REQUESTS.remove(request);
     }
-
-
-    /**
-     * Removes a list of {@link VideoRequest} from storage. Called when video grabbing is done.
-     *
-     * @param requests {@link List} of {@link VideoRequest}
-     */
-    public void remove(List<VideoRequest> requests) {
-
-        if (VIDEO_WEBDRIVER_REQUESTS.get() != null) {
-            VIDEO_WEBDRIVER_REQUESTS.get().removeAll(requests);
-        }
-
-        GLOBAL_VIDEO_WEBDRIVER_REQUESTS.removeAll(requests);
-    }
-
-    /**
-     * Clears ALL Thread-Local and GLOBAL DATA.
-     */
-    public void clear() {
-
-        if (VIDEO_WEBDRIVER_REQUESTS.get() != null) {
-            VIDEO_WEBDRIVER_REQUESTS.get().clear();
-        }
-
-        GLOBAL_VIDEO_WEBDRIVER_REQUESTS.clear();
-    }
-
 }

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
@@ -61,7 +61,11 @@ public class SelenoidHelper implements Loggable {
 
     }
 
-    public void updateNodeInfo(URL seleniumUrl, String remoteSessionId, SessionContext sessionContext) {
+    /**
+     * Updates the selenoid node info
+     * @return TRUE if this node is a Selenoid node, otherwise FALSE
+     */
+    public boolean updateNodeInfo(URL seleniumUrl, String remoteSessionId, SessionContext sessionContext) {
         String url = seleniumUrl.toString();
 
         url = url.replace("/wd/hub", "");
@@ -75,8 +79,10 @@ public class SelenoidHelper implements Loggable {
             Map map = gson.fromJson(nodeResponse, Map.class);
             double port = Double.parseDouble(map.get("Port").toString());
             sessionContext.setNodeInfo(new NodeInfo(map.get("Name").toString(), (int) port));
+            return true;
         } catch (Exception e) {
             log().warn("Could not get node info: " + e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/VideoDesktopWebDriverFactory.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/VideoDesktopWebDriverFactory.java
@@ -71,17 +71,21 @@ public class VideoDesktopWebDriverFactory extends DesktopWebDriverFactory {
         final WebDriver rawWebDriver = super.getRawWebDriver(request, desiredCapabilities, sessionContext);
 
         if (rawWebDriver instanceof RemoteWebDriver && request.getSeleniumServerUrl() != null) {
-            SelenoidHelper.get().updateNodeInfo(request.getSeleniumServerUrl(), ((RemoteWebDriver) rawWebDriver).getSessionId().toString(), sessionContext);
+
+            // Only create video requests for Selenoid nodes
+            if (selenoidHelper.updateNodeInfo(request.getSeleniumServerUrl(), ((RemoteWebDriver) rawWebDriver).getSessionId().toString(), sessionContext)) {
+
+                // create a VideoRequest with request and videoName
+                final VideoRequest videoRequest = new VideoRequest(sessionContext, videoCaps.asMap().get(SelenoidCapabilityProvider.Caps.videoName.toString()).toString());
+
+                // store it.
+                videoRequestStorage.store(videoRequest);
+
+                // get vnc path and log
+                log().info("VNC Streaming URL: " + selenoidHelper.getRemoteVncUrl(videoRequest));
+            }
         }
 
-        // create a VideoRequest with request and videoName
-        final VideoRequest videoRequest = new VideoRequest(sessionContext, videoCaps.asMap().get(SelenoidCapabilityProvider.Caps.videoName.toString()).toString());
-
-        // store it.
-        videoRequestStorage.store(videoRequest);
-
-        // get vnc path and log
-        log().info("VNC Streaming URL: " + selenoidHelper.getRemoteVncUrl(videoRequest));
         return rawWebDriver;
     }
 }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/AbstractSelenoidTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/AbstractSelenoidTest.java
@@ -1,0 +1,90 @@
+/*
+ * Testerra
+ *
+ * (C) 2021, Mike Reiche,  T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package eu.tsystems.mms.tic.testerra.plugins.selenoid;
+
+import eu.tsystems.mms.tic.testframework.constants.Browsers;
+import eu.tsystems.mms.tic.testframework.report.model.context.ClassContext;
+import eu.tsystems.mms.tic.testframework.report.model.context.MethodContext;
+import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
+import eu.tsystems.mms.tic.testframework.report.model.context.SuiteContext;
+import eu.tsystems.mms.tic.testframework.report.model.context.TestContext;
+import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
+import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
+import eu.tsystems.mms.tic.testframework.useragents.ChromeConfig;
+import eu.tsystems.mms.tic.testframework.useragents.FirefoxConfig;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverProxyUtils;
+import java.util.Optional;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.testng.Assert;
+import org.testng.ITestResult;
+import org.testng.annotations.BeforeSuite;
+
+public abstract class AbstractSelenoidTest extends TesterraTest {
+
+    @BeforeSuite
+    public void configureChromeOptions() {
+        Proxy proxy = new WebDriverProxyUtils().getDefaultHttpProxy();
+
+        WebDriverManager.setUserAgentConfig(Browsers.chrome, new ChromeConfig() {
+            @Override
+            public void configure(ChromeOptions options) {
+                options.setProxy(proxy);
+            }
+        });
+
+        WebDriverManager.setUserAgentConfig(Browsers.firefox, new FirefoxConfig() {
+            @Override
+            public void configure(FirefoxOptions firefoxOptions) {
+                firefoxOptions.setProxy(proxy);
+            }
+        });
+
+    }
+
+    protected boolean Video_is_present_in_SessionContext(String methodName, boolean expectPresence) {
+        Optional<MethodContext> optionalMethodContext = ExecutionContextController.getCurrentExecutionContext().readSuiteContexts()
+                .flatMap(SuiteContext::readTestContexts)
+                .flatMap(TestContext::readClassContexts)
+                .filter(classContext -> classContext.getTestClass().equals(this.getClass()))
+                .flatMap(ClassContext::readMethodContexts)
+                .filter(methodContext -> {
+                    Optional<ITestResult> testNgResult = methodContext.getTestNgResult();
+                    return (testNgResult.isPresent() && testNgResult.get().getMethod().getMethodName().equals(methodName));
+                })
+                .findFirst();
+
+        Assert.assertTrue(optionalMethodContext.isPresent(), String.format("MethodContext \"%s\" found", methodName));
+
+        MethodContext methodContext = optionalMethodContext.get();
+        Optional<SessionContext> optionalSessionContext = methodContext.readSessionContexts().findFirst();
+
+        Assert.assertTrue(optionalSessionContext.isPresent(), String.format("MethodContext \"%s\" has session context", methodName));
+
+        boolean videoPresent = optionalSessionContext.get().getVideo().isPresent();
+        Assert.assertEquals(expectPresence, videoPresent, String.format("SessionContext for MethodContext \"%s\" has video", methodName));
+
+        return expectPresence == videoPresent;
+    }
+}

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/AbstractSelenoidTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/AbstractSelenoidTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractSelenoidTest extends TesterraTest {
         Assert.assertTrue(optionalSessionContext.isPresent(), String.format("MethodContext \"%s\" has session context", methodName));
 
         boolean videoPresent = optionalSessionContext.get().getVideo().isPresent();
-        Assert.assertEquals(expectPresence, videoPresent, String.format("SessionContext for MethodContext \"%s\" has video", methodName));
+        Assert.assertEquals(videoPresent, expectPresence, String.format("SessionContext for MethodContext \"%s\" has video", methodName));
 
         return expectPresence == videoPresent;
     }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/AbstractSelenoidTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/AbstractSelenoidTest.java
@@ -63,7 +63,7 @@ public abstract class AbstractSelenoidTest extends TesterraTest {
 
     }
 
-    protected boolean Video_is_present_in_SessionContext(String methodName, boolean expectPresence) {
+    protected boolean isVideoPresentInMethodContext(String methodName, boolean expectPresence) {
         Optional<MethodContext> optionalMethodContext = ExecutionContextController.getCurrentExecutionContext().readSuiteContexts()
                 .flatMap(SuiteContext::readTestContexts)
                 .flatMap(TestContext::readClassContexts)

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ExclusiveSessionSelenoidVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ExclusiveSessionSelenoidVideoTest.java
@@ -45,7 +45,7 @@ public class ExclusiveSessionSelenoidVideoTest extends AbstractSelenoidTest impl
     }
 
     @Test(dependsOnMethods = "testT03_FailingTestWillStopVideo", alwaysRun = true)
-    public void test_Video_is_present_after_execution() {
+    public void test_VideoIsPresent_after_FailingTestWillStopVideo() {
 
         ExclusiveSessionSelenoidVideoTest self = this;
 

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ExclusiveSessionSelenoidVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ExclusiveSessionSelenoidVideoTest.java
@@ -1,5 +1,9 @@
 package eu.tsystems.mms.tic.testerra.plugins.selenoid;
 
+import com.google.common.eventbus.Subscribe;
+import eu.tsystems.mms.tic.testframework.events.ExecutionFinishEvent;
+import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import eu.tsystems.mms.tic.testframework.report.TesterraListener;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
 import org.junit.Assert;
@@ -14,7 +18,7 @@ import org.testng.annotations.Test;
  *
  * @author Eric Kubenka
  */
-public class ExclusiveSessionSelenoidVideoTest extends TesterraTest {
+public class ExclusiveSessionSelenoidVideoTest extends AbstractSelenoidTest implements Loggable {
 
     private static String WEBDRIVER_SESSION = "";
 
@@ -39,5 +43,22 @@ public class ExclusiveSessionSelenoidVideoTest extends TesterraTest {
         final WebDriver driver = WebDriverManager.getWebDriver(WEBDRIVER_SESSION);
         driver.get("https://golem.de");
         Assert.fail("This should fail.");
+    }
+
+    @Test(dependsOnMethods = "testT03_FailingTestWillStopVideo", alwaysRun = true)
+    public void test_Video_is_present_after_execution() {
+
+        ExclusiveSessionSelenoidVideoTest self = this;
+
+        TesterraListener.getEventBus().register(new ExecutionFinishEvent.Listener() {
+            @Override
+            @Subscribe
+            public void onExecutionFinish(ExecutionFinishEvent event) {
+                /**
+                 * TODO: Move that into a TestUnderTest
+                 */
+                self.Video_is_present_in_SessionContext("testT03_FailingTestWillStopVideo", true);
+            }
+        });
     }
 }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ExclusiveSessionSelenoidVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ExclusiveSessionSelenoidVideoTest.java
@@ -4,7 +4,6 @@ import com.google.common.eventbus.Subscribe;
 import eu.tsystems.mms.tic.testframework.events.ExecutionFinishEvent;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import eu.tsystems.mms.tic.testframework.report.TesterraListener;
-import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
 import org.junit.Assert;
 import org.openqa.selenium.WebDriver;
@@ -57,7 +56,7 @@ public class ExclusiveSessionSelenoidVideoTest extends AbstractSelenoidTest impl
                 /**
                  * TODO: Move that into a TestUnderTest
                  */
-                self.Video_is_present_in_SessionContext("testT03_FailingTestWillStopVideo", true);
+                self.isVideoPresentInMethodContext("testT03_FailingTestWillStopVideo", true);
             }
         });
     }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ReusedSessionsVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ReusedSessionsVideoTest.java
@@ -37,7 +37,7 @@ public class ReusedSessionsVideoTest extends AbstractSelenoidTest {
     private WebDriver webDriver;
 
     @Test()
-    public void test_fails_without_closing_webdriver() {
+    public void test_FailsWithoutClosingWebdriver() {
         System.setProperty(TesterraProperties.CLOSE_WINDOWS_AFTER_TEST_METHODS, "false");
         System.setProperty(TesterraProperties.CLOSE_WINDOWS_ON_FAILURE, "false");
         WebDriverManagerConfig config = WebDriverManager.getConfig();
@@ -47,8 +47,8 @@ public class ReusedSessionsVideoTest extends AbstractSelenoidTest {
         Assert.fail("must fail");
     }
 
-    @Test(dependsOnMethods = "test_fails_without_closing_webdriver", alwaysRun = true)
-    public void test_Video_is_present_after_execution() {
+    @Test(dependsOnMethods = "test_FailsWithoutClosingWebdriver", alwaysRun = true)
+    public void test_VideoIsPresent_after_FailsWithoutClosingWebdriver() {
         Assert.assertTrue(WebDriverSessionsManager.getSessionContext(this.webDriver).isPresent(), "SessionContext is present");
         WebDriverManagerConfig config = WebDriverManager.getConfig();
 
@@ -72,7 +72,7 @@ public class ReusedSessionsVideoTest extends AbstractSelenoidTest {
                 /**
                  * TODO: Move that into a TestUnderTest
                  */
-                self.isVideoPresentInMethodContext("test_fails_without_closing_webdriver", true);
+                self.isVideoPresentInMethodContext("test_FailsWithoutClosingWebdriver", true);
             }
         });
     }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ReusedSessionsVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ReusedSessionsVideoTest.java
@@ -72,7 +72,7 @@ public class ReusedSessionsVideoTest extends AbstractSelenoidTest {
                 /**
                  * TODO: Move that into a TestUnderTest
                  */
-                self.Video_is_present_in_SessionContext("test_fails_without_closing_webdriver", true);
+                self.isVideoPresentInMethodContext("test_fails_without_closing_webdriver", true);
             }
         });
     }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ReusedSessionsVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/ReusedSessionsVideoTest.java
@@ -1,0 +1,79 @@
+/*
+ * Testerra
+ *
+ * (C) 2021, Mike Reiche,  T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package eu.tsystems.mms.tic.testerra.plugins.selenoid;
+
+import com.google.common.eventbus.Subscribe;
+import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
+import eu.tsystems.mms.tic.testframework.events.ExecutionFinishEvent;
+import eu.tsystems.mms.tic.testframework.report.TesterraListener;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManagerConfig;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
+import org.openqa.selenium.WebDriver;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ReusedSessionsVideoTest extends AbstractSelenoidTest {
+
+    private WebDriver webDriver;
+
+    @Test()
+    public void test_fails_without_closing_webdriver() {
+        System.setProperty(TesterraProperties.CLOSE_WINDOWS_AFTER_TEST_METHODS, "false");
+        System.setProperty(TesterraProperties.CLOSE_WINDOWS_ON_FAILURE, "false");
+        WebDriverManagerConfig config = WebDriverManager.getConfig();
+        config.reset();
+        this.webDriver = WebDriverManager.getWebDriver();
+        this.webDriver.get("https://the-internet.herokuapp.com");
+        Assert.fail("must fail");
+    }
+
+    @Test(dependsOnMethods = "test_fails_without_closing_webdriver", alwaysRun = true)
+    public void test_Video_is_present_after_execution() {
+        Assert.assertTrue(WebDriverSessionsManager.getSessionContext(this.webDriver).isPresent(), "SessionContext is present");
+        WebDriverManagerConfig config = WebDriverManager.getConfig();
+
+        Assert.assertFalse(config.shouldShutdownSessionAfterTestMethod());
+        Assert.assertFalse(config.shouldShutdownSessionOnFailure());
+
+        System.setProperty(TesterraProperties.CLOSE_WINDOWS_AFTER_TEST_METHODS, "true");
+        System.setProperty(TesterraProperties.CLOSE_WINDOWS_ON_FAILURE, "true");
+
+        config.reset();
+
+        Assert.assertTrue(config.shouldShutdownSessionAfterTestMethod());
+        Assert.assertTrue(config.shouldShutdownSessionOnFailure());
+
+        ReusedSessionsVideoTest self = this;
+
+        TesterraListener.getEventBus().register(new ExecutionFinishEvent.Listener() {
+            @Override
+            @Subscribe
+            public void onExecutionFinish(ExecutionFinishEvent event) {
+                /**
+                 * TODO: Move that into a TestUnderTest
+                 */
+                self.Video_is_present_in_SessionContext("test_fails_without_closing_webdriver", true);
+            }
+        });
+    }
+}

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
@@ -20,7 +20,7 @@ public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
         driver.get("https://the-internet.herokuapp.com");
     }
 
-    @Test(dependsOnMethods = "testT01_SuccessfulTestCaseWillNotCreateVideo", alwaysRun = true)
+    @Test( dependsOnMethods = "testT01_SuccessfulTestCaseWillNotCreateVideo", alwaysRun = true)
     public void test_Video_is_not_present_in_SessionContext_on_passed_test() {
         this.Video_is_present_in_SessionContext("testT01_SuccessfulTestCaseWillNotCreateVideo", false);
     }
@@ -36,18 +36,6 @@ public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
     @Test(dependsOnMethods = "testT02_FailedTestCaseWillCreateVideo", alwaysRun = true)
     public void test_Video_is_present_in_SessionContext_on_failed_test() {
         this.Video_is_present_in_SessionContext("testT02_FailedTestCaseWillCreateVideo", true);
-    }
-
-    @Test()
-    public void test_fails_without_closing_webdriver() {
-        WebDriverManager.getConfig().setShutdownSessionAfterTestMethod(false);
-        final WebDriver driver = WebDriverManager.getWebDriver();
-        driver.get("https://the-internet.herokuapp.com");
-    }
-
-    @Test(dependsOnMethods = "test_fails_without_closing_webdriver")
-    public void test_Video_is_present_after_manually_closed() {
-        WebDriverManager.forceShutdown();
     }
 
     @Test

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
@@ -1,20 +1,9 @@
 package eu.tsystems.mms.tic.testerra.plugins.selenoid;
 
-import eu.tsystems.mms.tic.testframework.constants.Browsers;
 import eu.tsystems.mms.tic.testframework.execution.testng.AssertCollector;
-import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
-import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
-import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
-import eu.tsystems.mms.tic.testframework.useragents.ChromeConfig;
-import eu.tsystems.mms.tic.testframework.useragents.FirefoxConfig;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
-import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverProxyUtils;
-import org.junit.Assert;
-import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxOptions;
-import org.testng.annotations.BeforeSuite;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
@@ -23,32 +12,17 @@ import org.testng.annotations.Test;
  *
  * @author Eric Kubenka
  */
-public class SimpleSelenoidVideoTest extends TesterraTest {
+public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
 
-    @BeforeSuite
-    public void configureChromeOptions() {
-        Proxy proxy = new WebDriverProxyUtils().getDefaultHttpProxy();
-
-        WebDriverManager.setUserAgentConfig(Browsers.chrome, new ChromeConfig() {
-            @Override
-            public void configure(ChromeOptions options) {
-                options.setProxy(proxy);
-            }
-        });
-
-        WebDriverManager.setUserAgentConfig(Browsers.firefox, new FirefoxConfig() {
-            @Override
-            public void configure(FirefoxOptions firefoxOptions) {
-                firefoxOptions.setProxy(proxy);
-            }
-        });
-
-    }
-    @Test
+    @Test()
     public void testT01_SuccessfulTestCaseWillNotCreateVideo() {
-
         final WebDriver driver = WebDriverManager.getWebDriver();
         driver.get("https://the-internet.herokuapp.com");
+    }
+
+    @Test(dependsOnMethods = "testT01_SuccessfulTestCaseWillNotCreateVideo", alwaysRun = true)
+    public void test_Video_is_not_present_in_SessionContext_on_passed_test() {
+        this.Video_is_present_in_SessionContext("testT01_SuccessfulTestCaseWillNotCreateVideo", false);
     }
 
     @Test
@@ -61,7 +35,19 @@ public class SimpleSelenoidVideoTest extends TesterraTest {
 
     @Test(dependsOnMethods = "testT02_FailedTestCaseWillCreateVideo", alwaysRun = true)
     public void test_Video_is_present_in_SessionContext_on_failed_test() {
-        this.Video_is_present_in_SessionContext();
+        this.Video_is_present_in_SessionContext("testT02_FailedTestCaseWillCreateVideo", true);
+    }
+
+    @Test()
+    public void test_fails_without_closing_webdriver() {
+        WebDriverManager.getConfig().setShutdownSessionAfterTestMethod(false);
+        final WebDriver driver = WebDriverManager.getWebDriver();
+        driver.get("https://the-internet.herokuapp.com");
+    }
+
+    @Test(dependsOnMethods = "test_fails_without_closing_webdriver")
+    public void test_Video_is_present_after_manually_closed() {
+        WebDriverManager.forceShutdown();
     }
 
     @Test
@@ -73,13 +59,6 @@ public class SimpleSelenoidVideoTest extends TesterraTest {
 
     @Test(dependsOnMethods = "test_collect_Video_on_collected_assertion", alwaysRun = true)
     public void test_Video_is_present_in_SessionContext_on_collected_assertion() {
-        this.Video_is_present_in_SessionContext();
+        this.Video_is_present_in_SessionContext("test_collect_Video_on_collected_assertion",true);
     }
-
-    private void Video_is_present_in_SessionContext() {
-        SessionContext currentSessionContext = ExecutionContextController.getCurrentSessionContext();
-        Assert.assertNotNull(currentSessionContext);
-        Assert.assertTrue(currentSessionContext.getVideo().isPresent());
-    }
-
 }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
@@ -21,7 +21,7 @@ public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
     }
 
     @Test( dependsOnMethods = "testT01_SuccessfulTestCaseWillNotCreateVideo", alwaysRun = true)
-    public void test_Video_is_not_present_in_SessionContext_on_passed_test() {
+    public void test_VideoIsNotPresent_after_SuccessfulTestCaseWillNotCreateVideo() {
         this.isVideoPresentInMethodContext("testT01_SuccessfulTestCaseWillNotCreateVideo", false);
     }
 
@@ -34,19 +34,19 @@ public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
     }
 
     @Test(dependsOnMethods = "testT02_FailedTestCaseWillCreateVideo", alwaysRun = true)
-    public void test_Video_is_present_in_SessionContext_on_failed_test() {
+    public void test_VideoIsPresent_after_FailedTestCaseWillCreateVideo() {
         this.isVideoPresentInMethodContext("testT02_FailedTestCaseWillCreateVideo", true);
     }
 
     @Test
-    public void test_collect_Video_on_collected_assertion() {
+    public void testT03_FailedTestWithCollectedAssertions() {
         final WebDriver driver = WebDriverManager.getWebDriver();
         driver.get("https://the-internet.herokuapp.com");
         AssertCollector.assertTrue(false);
     }
 
-    @Test(dependsOnMethods = "test_collect_Video_on_collected_assertion", alwaysRun = true)
-    public void test_Video_is_present_in_SessionContext_on_collected_assertion() {
+    @Test(dependsOnMethods = "testT03_FailedTestWithCollectedAssertions", alwaysRun = true)
+    public void test_VideoIsPresent_after_FailedTestWithCollectedAssertions() {
         this.isVideoPresentInMethodContext("test_collect_Video_on_collected_assertion",true);
     }
 }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
@@ -47,6 +47,6 @@ public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
 
     @Test(dependsOnMethods = "testT03_FailedTestWithCollectedAssertions", alwaysRun = true)
     public void test_VideoIsPresent_after_FailedTestWithCollectedAssertions() {
-        this.isVideoPresentInMethodContext("test_collect_Video_on_collected_assertion",true);
+        this.isVideoPresentInMethodContext("testT03_FailedTestWithCollectedAssertions",true);
     }
 }

--- a/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
+++ b/src/test/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/SimpleSelenoidVideoTest.java
@@ -22,7 +22,7 @@ public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
 
     @Test( dependsOnMethods = "testT01_SuccessfulTestCaseWillNotCreateVideo", alwaysRun = true)
     public void test_Video_is_not_present_in_SessionContext_on_passed_test() {
-        this.Video_is_present_in_SessionContext("testT01_SuccessfulTestCaseWillNotCreateVideo", false);
+        this.isVideoPresentInMethodContext("testT01_SuccessfulTestCaseWillNotCreateVideo", false);
     }
 
     @Test
@@ -35,7 +35,7 @@ public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
 
     @Test(dependsOnMethods = "testT02_FailedTestCaseWillCreateVideo", alwaysRun = true)
     public void test_Video_is_present_in_SessionContext_on_failed_test() {
-        this.Video_is_present_in_SessionContext("testT02_FailedTestCaseWillCreateVideo", true);
+        this.isVideoPresentInMethodContext("testT02_FailedTestCaseWillCreateVideo", true);
     }
 
     @Test
@@ -47,6 +47,6 @@ public class SimpleSelenoidVideoTest extends AbstractSelenoidTest {
 
     @Test(dependsOnMethods = "test_collect_Video_on_collected_assertion", alwaysRun = true)
     public void test_Video_is_present_in_SessionContext_on_collected_assertion() {
-        this.Video_is_present_in_SessionContext("test_collect_Video_on_collected_assertion",true);
+        this.isVideoPresentInMethodContext("test_collect_Video_on_collected_assertion",true);
     }
 }


### PR DESCRIPTION
# Description

Make the `SelenoidVideoCollector` reponsible to collection videos instead of `TestEvidenceCollector`.
* Fixes #8 
* Requires Testerra core change https://github.com/telekom/testerra/pull/34

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

![image](https://user-images.githubusercontent.com/572453/116427930-bdc55200-a844-11eb-9d47-9dfd8aace99c.png)
![image](https://user-images.githubusercontent.com/572453/116427945-c027ac00-a844-11eb-898a-28b0ae2148d4.png)
![image](https://user-images.githubusercontent.com/572453/116427956-c3229c80-a844-11eb-9fa7-be9e993a97eb.png)
