### PR TITLE
Fixes the missing session id in the VNC URL for Selenoid GGR instances

### DIFF
--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
@@ -140,13 +140,9 @@ public class SelenoidHelper implements Loggable {
      * @return String
      */
     public String getRemoteVncUrl(VideoRequest videoRequest, String sessionId) {
-        if (sessionId.length() >= 64) {
-            // It's a GGR session id, so cut first 32 chars
-            sessionId = sessionId.substring(32);
-        }
-        String finalSessionId = sessionId;
+        String selenoidSessionId = getSelenoidSessionId(Optional.ofNullable(sessionId));
         return videoRequest.sessionContext.getNodeInfo()
-                .map(nodeInfo -> VNC_ADDRESS + "?host=" + nodeInfo.getHost() + "&port=" + nodeInfo.getPort() + "&path=vnc/" + finalSessionId + "&autoconnect=true&password=selenoid")
+                .map(nodeInfo -> VNC_ADDRESS + "?host=" + nodeInfo.getHost() + "&port=" + nodeInfo.getPort() + "&path=vnc/" + selenoidSessionId + "&autoconnect=true&password=selenoid")
                 .orElse(null);
     }
 
@@ -267,7 +263,7 @@ public class SelenoidHelper implements Loggable {
     private String getSelenoidSessionId(Optional<String> optionalremoteSessionId) {
         return optionalremoteSessionId.map(remoteSessionId -> {
             if (remoteSessionId.length() >= 64) {
-                // its a ggr session id, so cut first 32
+                // It's a GGR session id, so cut the first 32 chars
                 remoteSessionId = remoteSessionId.substring(32);
             }
             return remoteSessionId;

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
@@ -140,8 +140,13 @@ public class SelenoidHelper implements Loggable {
      * @return String
      */
     public String getRemoteVncUrl(VideoRequest videoRequest, String sessionId) {
+        if (sessionId.length() >= 64) {
+            // It's a GGR session id, so cut first 32 chars
+            sessionId = sessionId.substring(32);
+        }
+        String finalSessionId = sessionId;
         return videoRequest.sessionContext.getNodeInfo()
-                .map(nodeInfo -> VNC_ADDRESS + "?host=" + nodeInfo.getHost() + "&port=" + nodeInfo.getPort() + "&path=vnc/" + sessionId + "&autoconnect=true&password=selenoid")
+                .map(nodeInfo -> VNC_ADDRESS + "?host=" + nodeInfo.getHost() + "&port=" + nodeInfo.getPort() + "&path=vnc/" + finalSessionId + "&autoconnect=true&password=selenoid")
                 .orElse(null);
     }
 


### PR DESCRIPTION
# Description

This is a fix of #11 in case a GGR is used instead of a single Selenoid instance. :unamused:

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
