### PR TITLE
Added property to change video download timeout (default are 20sec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,23 +169,24 @@ tt.selenoid.video.framerate=10
 
 ### Properties
 
-|Property|Default|Description|
-|---|---|---|
-|tt.screencaster.active|true|All videos will be collected in failure case of test method and for exclusive sessions.|
-|tt.screencaster.active.on.success|false|When true, generated video files will be attached the report for successful test methods|
-|tt.screencaster.active.on.failed|true|Generated video files will be attached the report for failed test methods|
-|tt.selenoid.vnc.enabled|true|VNC Stream will be activated and logged to the console.|
-|tt.selenoid.vnc.address|none|VNC Host address - Will be used to generate a unique url for accessing the VNC session. <br> For a hosted [noVNC server](https://github.com/novnc/noVNC) this should be `http://<host>:<port>/vnc.html`.|
-|tt.selenoid.video.framerate|2|Change the framerate of the video files.|
+| Property                           | Default | Description                                                                                                                                                                                              |
+|------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| tt.screencaster.active             | true    | All videos will be collected in failure case of test method and for exclusive sessions.                                                                                                                  |
+| tt.screencaster.active.on.success  | false   | When true, generated video files will be attached the report for successful test methods                                                                                                                 |
+| tt.screencaster.active.on.failed   | true    | Generated video files will be attached the report for failed test methods                                                                                                                                |
+| tt.selenoid.vnc.enabled            | true    | VNC Stream will be activated and logged to the console.                                                                                                                                                  |
+| tt.selenoid.vnc.address            | none    | VNC Host address - Will be used to generate a unique url for accessing the VNC session. <br> For a hosted [noVNC server](https://github.com/novnc/noVNC) this should be `http://<host>:<port>/vnc.html`. |
+| tt.selenoid.video.framerate        | 2       | Change the framerate of the video files.                                                                                                                                                                 |
+| tt.selenoid.video.download.timeout | 20000   | Set download timeout for Selenoid videos in ms.                                                                                                                                                          |
 
 ### Additional information
 
 The Selenoid connector adds some additional information to the new browser session. It uses the ``label`` capability to mark the session with the following information if available:
 
-|Label|Description|
-|---|---|
-| ReportName | Contains the Testerra report name |
-| RunConfig | Contains the Testerra run configuration |
+| Label      | Description                                  |
+|------------|----------------------------------------------|
+| ReportName | Contains the Testerra report name            |
+| RunConfig  | Contains the Testerra run configuration      |
 | Testmethod | Contains the current TestNG test method name |
 
 This feature is mentioned here: [https://aerokube.com/selenoid/latest/#_container_labels_labels]().

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidHelper.java
@@ -23,6 +23,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import eu.tsystems.mms.tic.testerra.plugins.selenoid.request.VideoRequest;
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
+import eu.tsystems.mms.tic.testframework.common.PropertyManagerProvider;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import eu.tsystems.mms.tic.testframework.model.NodeInfo;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
@@ -43,9 +44,11 @@ import java.util.Optional;
  *
  * @author Eric Kubenka
  */
-public class SelenoidHelper implements Loggable {
+public class SelenoidHelper implements PropertyManagerProvider, Loggable {
 
-    private static final String VNC_ADDRESS = PropertyManager.getProperty(SelenoidProperties.VNC_ADDRESS, SelenoidProperties.Default.VNC_ADDRESS);
+    private static final String VNC_ADDRESS = PROPERTY_MANAGER.getProperty(SelenoidProperties.VNC_ADDRESS, SelenoidProperties.Default.VNC_ADDRESS);
+
+    private static final long VIDEO_DOWNLOAD_TIMEOUT = PROPERTY_MANAGER.getLongProperty(SelenoidProperties.VIDEO_DOWNLOAD_TIMEOUT, 20000);
 
     private static final SelenoidHelper INSTANCE = new SelenoidHelper();
 
@@ -193,7 +196,7 @@ public class SelenoidHelper implements Loggable {
         final String videoName = "video_" + videoRequest.selenoidVideoName;
         final FileDownloader downloader = new FileDownloader();
 
-        final Timer timer = new Timer(5000, 20_000);
+        final Timer timer = new Timer(5000, VIDEO_DOWNLOAD_TIMEOUT);
         final ThrowablePackedResponse<String> response = timer.executeSequence(new Timer.Sequence<String>() {
             @Override
             public void run() throws Throwable {

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidProperties.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/utils/SelenoidProperties.java
@@ -16,6 +16,7 @@ public class SelenoidProperties {
     public static final String VNC_ENABLED = "tt.selenoid.vnc.enabled";
     public static final String VNC_ADDRESS = "tt.selenoid.vnc.address";
     public static final String VIDEO_FRAMERATE = "tt.selenoid.video.framerate";
+    public static final String VIDEO_DOWNLOAD_TIMEOUT = "tt.selenoid.video.download.timeout";
 
     public static class Default {
 


### PR DESCRIPTION
# Description

Added ability to change the timeout for video download. Default is 20 sec.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
