### PR TITLE
Added 'ggr:options' to get Selenoid labels in GGR logfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Hints:
 
 * You need at least **Selenoid 1.11.0** or above.
 * (*) From version 2.1 you need at least **JDK11**.
-* (**) Testerra 2.4 brings Selenium 4, you need at least Version 2.1
+* (**) Testerra 2.4 brings Selenium 4: 
+  * Using CDP support of Selenium 4, **Selenoid 1.11.0** (or later) is required
+* Using Selenium 4 _and_ custom labels _and_ a GGR in your grid, **GGR 1.7.2** (or later) and **Selenoid connector 2.2** (or later) are required 
 
 ### Usage
 

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/SelenoidCapabilities.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/SelenoidCapabilities.java
@@ -14,6 +14,8 @@ public class SelenoidCapabilities {
 
     public static String SELENOID_OPTIONS = "selenoid:options";
 
+    public static String GGR_OPTIONS = "ggr:options";
+
     public static String ENABLE_VNC = "enableVNC";
 
     public static String ENABLE_VIDEO = "enableVideo";

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/SelenoidCapabilityProvider.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/selenoid/webdriver/SelenoidCapabilityProvider.java
@@ -80,6 +80,8 @@ public class SelenoidCapabilityProvider implements Consumer<WebDriverRequest>, L
         }
         MutableCapabilities mutableCapabilities = new MutableCapabilities();
         mutableCapabilities.setCapability(SelenoidCapabilities.SELENOID_OPTIONS, selenoidOptions);
+        // Since GGR 1.7.2: Using an additional GGR label caps have to be added to 'ggr:options' (https://aerokube.com/ggr/latest/#_custom_labels_in_log_file)
+        mutableCapabilities.setCapability(SelenoidCapabilities.GGR_OPTIONS, selenoidOptions.get(SelenoidCapabilities.LABELS));
         return requestCaps.merge(mutableCapabilities);
     }
 


### PR DESCRIPTION
# Description

Added 'ggr:options' to capabilities to get Selenoid labels in GGR logfiles (https://aerokube.com/ggr/latest/#_custom_labels_in_log_file). 


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
